### PR TITLE
docker-compose mongodb volume fixed for Windows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,4 +49,7 @@ services:
     ports:
       - 27017:27017
     volumes:
-      - /tmp/meccg/mongo-data:/data/db
+      - mongodata:/data/db
+
+volumes:
+  mongodata:


### PR DESCRIPTION
With this little change compose.sh runs right in Windows 10