### PR TITLE
Feature/playinfobox

### DIFF
--- a/src/css/toastr.styl
+++ b/src/css/toastr.styl
@@ -8,5 +8,5 @@
   width: 60px
 
 .toast-card
-  top: 40%
-  right: 40%
+  top: 36px
+  right: 5px

--- a/src/css/toastr.styl
+++ b/src/css/toastr.styl
@@ -8,5 +8,5 @@
   width: 60px
 
 .toast-card
-  top: 36px
-  right: 5px
+  top: 40%
+  right: 40%


### PR DESCRIPTION
This is a simple CSS update to place the in game notification at the center of the screen.

Ususally, it is at the upper right and easy to miss. This patch will place it at the center.

![infobox](https://user-images.githubusercontent.com/75542195/108593138-e7a45900-7369-11eb-9380-373c2d9c9cc3.jpg)
