### PR TITLE
Update base.styl

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -2613,15 +2613,19 @@ align-radio
       z-index: 250
 
       .card-preview.blind
-        width: 200%
-        height: 200%
-        transform(translate(-160%, 0%))
-        transition(all 0.2s ease-in-out)
+        top: 0
+        left: 0
+        position: fixed
+        max-height: 590px
+        max-width: 400px
 
         &.region
           width: 200%
           height: 200%
           transform(translate(-122%, 0%) rotate(-90deg))
+
+        > img
+          position: relative
 
       .card-preview
         width: 100%


### PR DESCRIPTION
This patch places the card preview zoom box at the upper left of the browser instead of at the center.

Having it at the upper left allows you to preview-zoom cards of your opponents as well.

![preview](https://user-images.githubusercontent.com/75542195/108594693-5c2fc580-7373-11eb-8e77-21cc59a62960.png)
