### PR TITLE
Update base.styl

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1890,6 +1890,11 @@ align-radio
     min-width: 90px
     overflow: auto
 
+    .card
+      
+      &:hover
+        box-shadow: 0px 0px 5px 0px orange
+
     .contestant-rig, .challenger-rig, contestant-rig.opponent, .challenger-rig.opponent
       flex(1)
       display-flex()


### PR DESCRIPTION
add box shadow orange hover effect on cards on the board (but not anywhere else)

This also addresses the issue 18 on the cardnum issues board

![boxshadow](https://user-images.githubusercontent.com/75542195/108594942-ddd42300-7374-11eb-9f1c-a6ee850bd618.png)
