### PR TITLE
move deck view to the right

### DIFF
--- a/src/cljs/meccg/gameboard.cljs
+++ b/src/cljs/meccg/gameboard.cljs
@@ -1326,7 +1326,7 @@
             [:div {:on-click #(show-sideboard % owner side-ref)} "Sideboard"]
             [:div {:on-click #(show-fw-dc-sb % owner fwdc-ref)} "FW-DC-SB"]])
          (when (= (:side @game-state) side)
-           [:div.panel.blue-shade.popup {:ref deck-content-ref :style {:left -63}}
+           [:div.panel.blue-shade.popup {:ref deck-content-ref :style {:left 140}}
             [:div
              [:a {:on-click #(close-popup % owner deck-content-ref "stops looking at their deck" false false false false true)}
               "Close"]
@@ -1334,7 +1334,7 @@
               "Close & Shuffle"]]
             (om/build-all card-view deck {:key :cid})])
          (when (= (:side @game-state) side)
-           [:div.panel.blue-shade.popup {:ref side-content-ref :style {:left -63}}
+           [:div.panel.blue-shade.popup {:ref side-content-ref :style {:left 140}}
             [:div
              [:a {:on-click #(close-popup % owner side-content-ref "stops looking at their sideboard" false false true false false)}
               "Close"]
@@ -1343,7 +1343,7 @@
             (om/build-all card-view sideboard {:key :cid})]
            )
          (when (= (:side @game-state) side)
-           [:div.panel.blue-shade.popup {:ref fwdc-content-ref :style {:left -63}}
+           [:div.panel.blue-shade.popup {:ref fwdc-content-ref :style {:left 140}}
             [:div
              [:a {:on-click #(close-popup % owner fwdc-content-ref "stops looking at their sideboard" false false false true false)}
               "Close"]


### PR DESCRIPTION
This moves the deck view to the right so you can hover over your cards and still zoom view them

![position](https://user-images.githubusercontent.com/75542195/110204574-94eb9680-7e6b-11eb-8f96-8d40f6c9e1be.png)
