### PR TITLE
Reorder Marshalling Points Pile

### DIFF
--- a/src/cljs/meccg/gameboard.cljs
+++ b/src/cljs/meccg/gameboard.cljs
@@ -2483,12 +2483,12 @@
               [:div.inner-leftpane
                [:div.left-inner-leftpane
                 [:div
-                 (om/build stats-view opponent)
                  (om/build scored-view opponent)
+                 (om/build stats-view opponent)
                  ]
                 [:div
-                 (om/build scored-view me)
-                 (om/build stats-view me)]
+                 (om/build stats-view me)
+                 (om/build scored-view me)]
                 ]
 
                [:div.right-inner-leftpane


### PR DESCRIPTION
This repositions the Marshaling Points pile. At the moment, it is not possible to zoom view your own scored cards.

![positioned](https://user-images.githubusercontent.com/75542195/110204816-0a0b9b80-7e6d-11eb-9ced-3835ef3d79f7.png)
