### PR TITLE
lazy image loading for faster pageload

### DIFF
--- a/src/cljs/meccg/cardbrowser.cljs
+++ b/src/cljs/meccg/cardbrowser.cljs
@@ -212,6 +212,7 @@
                                 (image-ice card true)
                                 (image-url card true)))]
                [:img {:src url
+                      :decoding "async"
                       :alt (:title card)
                       :onClick #(do (.preventDefault %)
                                     (put! (:pub-chan (om/get-shared owner))


### PR DESCRIPTION
Adds a 

`decoding="async" `
attribute to the images in the card list.

This should result in a faster loading time of the page. The card list images are loaded with every page start although you might not want to go to it. The browser will not wait for all the images to be decoded. See

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#attributes

