### PR TITLE
stats hover highlight

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1782,7 +1782,15 @@ align-radio
     .controls
       float: right
       display: none
-      margin-top: -1px
+      margin-top: -18px
+
+    span
+      display: block;
+    
+    &:hover span
+      background: rgba(255,165,0,0.2);
+      padding-right: 10px;
+      border-radius: 4px;
 
     &:hover .controls
       display: block


### PR DESCRIPTION
This patch adds a hover effect to the stats to make it quite plain which stats entry you will be updating.

![box](https://user-images.githubusercontent.com/75542195/113862301-21a5af00-97a0-11eb-9443-e079226febaa.png)
