### PR TITLE
deck card preview size increased

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -1068,16 +1068,18 @@ align-radio
 
       .card-preview
         position: absolute
-        height: 443px
-        width: 310px
+        width: 450px;
+        max-height: 630px;
+        height: 100%;
         left: auto
         z-index: 10
         right: 5px
         top: 0
 
       .edit .card-preview
-        height: 443px
-        width: 310px
+        width: 450px;
+        max-height: 630px;
+        height: 100%;
         right: -100%
         transform: translateX(100%)
         margin-right: -17px


### PR DESCRIPTION
Increase the card preview size on deck view and edit page. There is enough space available, so the image will be scaled to 450px width.

See examples below

![edit-deck](https://user-images.githubusercontent.com/75542195/119223222-14464900-baf0-11eb-927d-aa946e311573.png)
![view-deck](https://user-images.githubusercontent.com/75542195/119223224-16a8a300-baf0-11eb-9988-4d26a1f5c624.png)
