### PR TITLE
increase card browser image

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -954,8 +954,8 @@ align-radio
 .card-preview
   float: left
   position: relative
-  height: 348px
-  width: 250px
+  height: 450px
+  width: 340px
   margin: 0 10px 10px 2px
   border-radius: 8px
   padding: 10px


### PR DESCRIPTION
This PR increases the card preview images in the card browser. Especially on larger screens, the images cannot be read easily, because the text is too small.

Before:
![before](https://user-images.githubusercontent.com/75542195/173196686-d68a698f-cf2b-4868-adb6-c79e466134a2.png)

After:
![after](https://user-images.githubusercontent.com/75542195/173196696-90baa9fc-69c3-4473-8595-bfb8f39f68de.png)

