### PR TITLE
Remove "unimplemented" info box in game

### DIFF
--- a/src/css/base.styl
+++ b/src/css/base.styl
@@ -2652,6 +2652,7 @@ align-radio
 
     // Card implementation div
     .implementation
+      display: none
       width: 150px
       position: absolute
       top: 0


### PR DESCRIPTION
This PR removes the red "unimplemented" notification box. It is of no use for the player. Importantly, the CSS update only hides it, because it may be necessary later, so it can be restored easily. Probably better to remove it from the Clojure, but I cannot test this, so i chose the CSS fix.

Before:
![before](https://user-images.githubusercontent.com/75542195/173197318-b9bb1eaf-fff9-4731-830f-19a18a060e04.png)

After:
![after](https://user-images.githubusercontent.com/75542195/173197322-7f58538a-aa05-4149-860f-eb9e4b89a98f.png)

